### PR TITLE
Minor changes to transfer encoding scripts ...

### DIFF
--- a/src/main/scripts/org/reaktivity/specification/http/rfc7230/transfer.codings/response.transfer.encoding.chunked/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http/rfc7230/transfer.codings/response.transfer.encoding.chunked/client.rpt
@@ -16,22 +16,22 @@
 
 property newServerAcceptRef  ${nuklei:newReferenceId()} # external
 
+property clientInitialWindow 8192
+
 connect await ROUTED_SERVER
         "http://localhost:8080/"
   option http:transport "nukleus://http/streams/source"
   option nukleus:route ${newServerAcceptRef}
-  option nukleus:window 8192
+  option nukleus:window ${clientInitialWindow}
   option nukleus:transmission "duplex"
 connected
 
 write http:method "GET"
 write http:host
-write http:header "Content-Type" "text/plain"
 write http:content-length
 write close
 
 read http:status "200" "OK"
-read http:header "Content-Type" "text/plain"
 read http:header "Transfer-Encoding" "chunked"
 read "Chunk A;"
 read "Chunk B;"

--- a/src/main/scripts/org/reaktivity/specification/http/rfc7230/transfer.codings/response.transfer.encoding.chunked/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http/rfc7230/transfer.codings/response.transfer.encoding.chunked/server.rpt
@@ -27,11 +27,9 @@ accepted
 connected
 
 read http:method "GET"
-read http:header "Content-Type" "text/plain"
 read closed
 
 write http:status "200" "OK"
-write http:header "Content-Type" "text/plain"
 write http:header "Transfer-Encoding" "chunked"
 write "Chunk A;"
 write "Chunk B;"

--- a/src/main/scripts/org/reaktivity/specification/nukleus/http/streams/rfc7230/transfer.codings/response.transfer.encoding.chunked/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/http/streams/rfc7230/transfer.codings/response.transfer.encoding.chunked/client.rpt
@@ -15,25 +15,24 @@
 #
 
 property newClientAcceptRef  ${nuklei:newReferenceId()} # external
+property clientInitialWindow 8192
 
 connect await ROUTED_CLIENT
         "nukleus://http/streams/source"
   option nukleus:route ${newClientAcceptRef}
-  option nukleus:window 8192
+  option nukleus:window ${clientInitialWindow}
   option nukleus:transmission "half-duplex"
 
 write nukleus:begin.ext ${http:header(":scheme", "http")}
 write nukleus:begin.ext ${http:header(":method", "GET")}
 write nukleus:begin.ext ${http:header(":path", "/")}
 write nukleus:begin.ext ${http:header(":authority", "localhost:8080")}
-write nukleus:begin.ext ${http:header("content-type", "text/plain")}
 write nukleus:begin.ext ${http:header("content-length", "0")}
 connected
 
 write close
 
 read nukleus:begin.ext ${http:header(":status", "200")}
-read nukleus:begin.ext ${http:header("content-type", "text/plain")}
 read nukleus:begin.ext ${http:header("transfer-encoding", "chunked")}
 
 read "Chunk A;"

--- a/src/main/scripts/org/reaktivity/specification/nukleus/http/streams/rfc7230/transfer.codings/response.transfer.encoding.chunked/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/http/streams/rfc7230/transfer.codings/response.transfer.encoding.chunked/server.rpt
@@ -30,13 +30,11 @@ read nukleus:begin.ext ${http:header(":scheme", "http")}
 read nukleus:begin.ext ${http:header(":method", "GET")}
 read nukleus:begin.ext ${http:header(":path", "/")}
 read nukleus:begin.ext ${http:header(":authority", "localhost:8080")}
-read nukleus:begin.ext ${http:header("content-type", "text/plain")}
 connected
 
 read closed
 
 write nukleus:begin.ext ${http:header(":status", "200")}
-write nukleus:begin.ext ${http:header("content-type", "text/plain")}
 write nukleus:begin.ext ${http:header("transfer-encoding", "chunked")}
 
 write "Chunk A;"


### PR DESCRIPTION
... to allow them to be used test various edge cases: mainly removing content-type header so the request and response headers do not exceed 64 bytes in length so we can test with slot size of 64.