### PR TITLE
Fix sporadic test failures

### DIFF
--- a/src/main/scripts/org/reaktivity/specification/http/rfc7230/connection.management/request.response.and.reset/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http/rfc7230/connection.management/request.response.and.reset/server.rpt
@@ -35,6 +35,7 @@ write "\r\n"
 read await RESPONSE_DECODED
 
 read abort
+write aborted
 
 read notify CONNECTION_RESET
 

--- a/src/main/scripts/org/reaktivity/specification/http/rfc7230/message.format/request.with.headers/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http/rfc7230/message.format/request.with.headers/client.rpt
@@ -21,9 +21,12 @@ connect await ROUTED_SERVER
   option http:transport "nukleus://http/streams/source"
   option nukleus:route ${newServerAcceptRef}
   option nukleus:window 8192
-  option nukleus:transmission "simplex"
+  option nukleus:transmission "half-duplex"
 connected
 
 write http:method "GET"
 write http:header "some" "header"
 write close
+
+read http:status "200" /.*/
+

--- a/src/main/scripts/org/reaktivity/specification/http/rfc7230/message.format/request.with.headers/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http/rfc7230/message.format/request.with.headers/server.rpt
@@ -22,7 +22,7 @@ accept "http://localhost:8080/"
   option http:transport ${serverTransport}
   option nukleus:route ${newClientConnectRef}
   option nukleus:window 8192
-  option nukleus:transmission "duplex"
+  option nukleus:transmission "half-duplex"
 accepted
 connected
 


### PR DESCRIPTION
Fixes to address sporadic test failures in nukleus-http.java, tests 
-  `client.ConnectionManagementPoolSize1IT.shouldEndOutputAndFreeConnectionWhenResetReceivedAfterCompleteResponse` and 
- `server.MessageFormatIT.requestWithHeaders`